### PR TITLE
Updates to conan to avoid circular dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,43 +57,6 @@ set(SIMCENTER_MODULE_DIRS  ${SIMCENTER_MODULE_DIRS} CACHE INTERNAL "All folders 
 
 # Bring in dependencies from Conan, only getting required libs for Intel MKL and IPP
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-
-set(mkl_libs)
-set(ipp_libs)
-set(needed_mkl_libs "mkl_intel_lp64" "mkl_sequential" "mkl_core")
-if (WIN32)
-  set(needed_ipp_libs "ippcoremt" "ippvmmt" "ippsmt")
-else()
-  set(needed_ipp_libs "ippcore" "ippvm" "ipps")  
-endif()
-
-if (UNIX AND NOT APPLE)
-  list(APPEND mkl_libs "-Wl,--start-group")  
-endif()
-
-foreach( needed_lib ${needed_mkl_libs} )
-  foreach( _library ${CONAN_LIBS_MKL-STATIC} )
-    if(${_library} MATCHES ${needed_lib})
-      list(APPEND mkl_libs ${_library})
-    endif()
-  endforeach()
-endforeach()
-
-if (UNIX AND NOT APPLE)
-  list(APPEND mkl_libs "-Wl,--start-group")
-endif()
-
-foreach( needed_lib ${needed_ipp_libs} )
-  foreach( _library ${CONAN_LIBS_IPP-STATIC} )
-    if(${_library} MATCHES ${needed_lib})
-      list(APPEND ipp_libs ${_library})
-    endif()
-  endforeach()
-endforeach()
-
-set(CONAN_LIBS_MKL-STATIC ${mkl_libs})
-set(CONAN_LIBS_IPP-STATIC ${ipp_libs})
-
 conan_basic_setup(TARGETS)
 
 ############################################################################################################################

--- a/build.py
+++ b/build.py
@@ -4,5 +4,5 @@
 from bincrafters import build_template_default
 
 if __name__ == "__main__":   
-    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"], shared_option_name=["False"])
+    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"])
     builder.run()

--- a/build.py
+++ b/build.py
@@ -4,5 +4,5 @@
 from bincrafters import build_template_default
 
 if __name__ == "__main__":   
-    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"])
+    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"], shared=["False"])
     builder.run()

--- a/build.py
+++ b/build.py
@@ -4,5 +4,5 @@
 from bincrafters import build_template_default
 
 if __name__ == "__main__":   
-    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"], shared=["False"])
+    builder = build_template_default.get_builder(build_types=["Release"], archs=["x86_64"], shared_option_name=["False"])
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class simCenterBackendApps(ConanFile):
     author = "Michael Gardner mhgardner@berkeley.edu"
     url = "https://github.com/NHERI-SimCenter/SimCenterBackendApplications"
     settings = {"os": None, "build_type": None, "compiler": None, "arch": ["x86_64"]}
-    options = {"shared": [False]}
+    options = {"shared": [True, False]}
     # default_options = {"shared": False}    
     generators = "cmake"
     build_policy = "missing"

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class simCenterBackendApps(ConanFile):
     url = "https://github.com/NHERI-SimCenter/SimCenterBackendApplications"
     settings = {"os": None, "build_type": None, "compiler": None, "arch": ["x86_64"]}
     options = {"shared": [True, False]}
-    # default_options = {"shared": False}    
+    default_options = {"mkl-static:threaded": False, "ipp-static:simcenter_backend": True}    
     generators = "cmake"
     build_policy = "missing"
     requires = "jansson/2.11@bincrafters/stable", \

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,17 +28,17 @@ class simCenterBackendApps(ConanFile):
     _build_subfolder = "build_subfolder"
     # Set short paths for Windows
     short_paths = True    
-    scm = {
-        "type": "git",  # Use "type": "svn", if local repo is managed using SVN
-        "subfolder": _source_subfolder,
-        "url": "auto",
-        "revision": "auto"
-    }
+    # scm = {
+    #     "type": "git",  # Use "type": "svn", if local repo is managed using SVN
+    #     "subfolder": _source_subfolder,
+    #     "url": "auto",
+    #     "revision": "auto"
+    # }
 
     
-    # def source(self):
-    #    git = tools.Git(folder=self._source_subfolder)
-    #    git.clone("https://github.com/shellshocked2003/SimCenterBackendApplications", "stable/1.1.0")
+    def source(self):
+       git = tools.Git(folder=self._source_subfolder)
+       git.clone("https://github.com/shellshocked2003/SimCenterBackendApplications", "stable/1.1.0")
 
     def configure(self):
         self.options.shared = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,10 +28,17 @@ class simCenterBackendApps(ConanFile):
     _build_subfolder = "build_subfolder"
     # Set short paths for Windows
     short_paths = True    
+    scm = {
+        "type": "git",  # Use "type": "svn", if local repo is managed using SVN
+        "subfolder": _source_subfolder,
+        "url": "auto",
+        "revision": "auto"
+    }
 
-    def source(self):
-       git = tools.Git(folder=self._source_subfolder)
-       git.clone("https://github.com/shellshocked2003/SimCenterBackendApplications", "stable/1.1.0")
+    
+    # def source(self):
+    #    git = tools.Git(folder=self._source_subfolder)
+    #    git.clone("https://github.com/shellshocked2003/SimCenterBackendApplications", "stable/1.1.0")
 
     def configure(self):
         self.options.shared = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class simCenterBackendApps(ConanFile):
     author = "Michael Gardner mhgardner@berkeley.edu"
     url = "https://github.com/NHERI-SimCenter/SimCenterBackendApplications"
     settings = {"os": None, "build_type": None, "compiler": None, "arch": ["x86_64"]}
-    options = {"shared": [True, False]}
+    options = {"shared": [False]}
     # default_options = {"shared": False}    
     generators = "cmake"
     build_policy = "missing"

--- a/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
+++ b/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
@@ -1,3 +1,3 @@
 simcenter_add_executable(NAME StochasticGM
                          DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt CONAN_PKG::clara CONAN_PKG::jsonformoderncpp)
+                         CONAN_PKG::smelt)

--- a/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
+++ b/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
@@ -1,3 +1,2 @@
 simcenter_add_executable(NAME StochasticGM
-                         DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt)
+                         DEPENDS CONAN_PKG::smelt CONAN_PKG::ipp-static CONAN_PKG::mkl-static)

--- a/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
+++ b/modules/createEVENT/stochasticGroundMotion/CMakeLists.txt
@@ -1,3 +1,3 @@
 simcenter_add_executable(NAME StochasticGM
                          DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt CONAN_PKG::eigen CONAN_PKG::clara CONAN_PKG::jsonformoderncpp)
+                         CONAN_PKG::smelt CONAN_PKG::clara CONAN_PKG::jsonformoderncpp)

--- a/modules/createEVENT/stochasticWind/CMakeLists.txt
+++ b/modules/createEVENT/stochasticWind/CMakeLists.txt
@@ -1,3 +1,3 @@
 simcenter_add_executable(NAME StochasticWind
                          DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt CONAN_PKG::eigen CONAN_PKG::clara CONAN_PKG::jsonformoderncpp common)
+                         CONAN_PKG::smelt CONAN_PKG::clara CONAN_PKG::jsonformoderncpp common)

--- a/modules/createEVENT/stochasticWind/CMakeLists.txt
+++ b/modules/createEVENT/stochasticWind/CMakeLists.txt
@@ -1,3 +1,3 @@
 simcenter_add_executable(NAME StochasticWind
-                         DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt common)
+                         DEPENDS CONAN_PKG::smelt CONAN_PKG::ipp-static
+                         CONAN_PKG::mkl-static common)

--- a/modules/createEVENT/stochasticWind/CMakeLists.txt
+++ b/modules/createEVENT/stochasticWind/CMakeLists.txt
@@ -1,3 +1,3 @@
 simcenter_add_executable(NAME StochasticWind
                          DEPENDS CONAN_PKG::mkl-static CONAN_PKG::ipp-static
-                         CONAN_PKG::smelt CONAN_PKG::clara CONAN_PKG::jsonformoderncpp common)
+                         CONAN_PKG::smelt common)


### PR DESCRIPTION
This pull request includes the following:
* Removed dependency configuration from `CMake` and instead use options configuration in `conan` to configure dependencies
* Fixes in `CMake` configuration to address linking issues for `MKL` and `IPP`