### PR TITLE
JZ: filter grid points by extra keys

### DIFF
--- a/modules/common/simcenter_common.py
+++ b/modules/common/simcenter_common.py
@@ -85,7 +85,7 @@ unit_types = {
     'length'       : ['m', 'mm', 'cm', 'km', 'inch', 'ft', 'mile'],
     'area'         : ['m2', 'mm2', 'cm2', 'km2', 'inch2', 'ft2', 'mile2'],
     'volume'       : ['m3', 'mm3', 'cm3', 'km3', 'inch3', 'ft3', 'mile3'],
-    'speed'        : ['cmps', 'mps', 'mph', 'inchps', 'ftps'],
+    'speed'        : ['cmps', 'mps', 'mph', 'inchps', 'ftps', 'kph', 'fps', 'kts'],
     'acceleration' : ['mps2', 'cmps2', 'inchps2', 'ftps2', 'g'],
     'mass'         : ['kg', 'ton', 'lb'],
     'force'        : ['N', 'kN', 'lbf', 'kip', 'kips'],
@@ -141,6 +141,9 @@ mph = mile / h
 
 inchps = inch / sec
 ftps = ft / sec
+kph = km / h
+fps = ft / sec
+kts = 1.15078 * mph
 
 # acceleration
 mps2 = m / sec2

--- a/modules/performRegionalEventSimulation/regionalGroundMotion/CreateStation.py
+++ b/modules/performRegionalEventSimulation/regionalGroundMotion/CreateStation.py
@@ -80,7 +80,7 @@ class Station:
         return self.z2p5
 
 
-def create_stations(input_file, output_file, min_id, max_id, vs30_tag, z1_tag, z25_tag, zTR_tag=0, soil_flag=False, soil_model_type=None, soil_user_fun=None):
+def create_stations(input_file, output_file, filterIDs, vs30_tag, z1_tag, z25_tag, zTR_tag=0, soil_flag=False, soil_model_type=None, soil_user_fun=None):
     """
     Reading input csv file for stations and saving data to output json file
     Input:
@@ -102,15 +102,30 @@ def create_stations(input_file, output_file, min_id, max_id, vs30_tag, z1_tag, z
         run_tag = 0
         return run_tag
     # Max and Min IDs
-    stn_ids_min = np.min(stn_df.index.values)
-    stn_ids_max = np.max(stn_df.index.values)
-    if min_id is None:
-        min_id = stn_ids_min
-    if max_id is None:
-        max_id = stn_ids_max
-    min_id = np.max([stn_ids_min, min_id])
-    max_id = np.min([stn_ids_max, max_id])
-    selected_stn = copy.copy(stn_df.loc[min_id:max_id, :])
+    if filterIDs is not None:
+        stns_requested = []
+        for stns in filterIDs.split(','):
+            if "-" in stns:
+                stn_low, stn_high = stns.split("-")
+                stns_requested += list(range(int(stn_low), int(stn_high)+1))
+            else:
+                stns_requested.append(int(stns))
+        stns_requested = np.array(stns_requested)
+        stns_available = stn_df.index.values
+        stns_to_run = stns_requested[
+            np.where(np.in1d(stns_requested, stns_available))[0]]
+        selected_stn = stn_df.loc[stns_to_run]
+    else:
+        selected_stn = stn_df
+    # stn_ids_min = np.min(stn_df.index.values)
+    # stn_ids_max = np.max(stn_df.index.values)
+    # if min_id is None:
+    #     min_id = stn_ids_min
+    # if max_id is None:
+    #     max_id = stn_ids_max
+    # min_id = np.max([stn_ids_min, min_id])
+    # max_id = np.min([stn_ids_max, max_id])
+    # selected_stn = copy.copy(stn_df.loc[min_id:max_id, :])
     selected_stn.index = list(range(len(selected_stn.index)))
     # Extracting data
     labels = selected_stn.columns.values

--- a/modules/performRegionalEventSimulation/regionalGroundMotion/HazardSimulation.py
+++ b/modules/performRegionalEventSimulation/regionalGroundMotion/HazardSimulation.py
@@ -117,15 +117,12 @@ def hazard_job(hazard_info):
         output_file = site_info.get('output_file',False)
         if output_file:
             output_file = os.path.join(input_dir, output_file)
-        min_ID = site_info['min_ID']
-        max_ID = site_info['max_ID']
-        # forward compatibility
-        if minID:
-            min_ID = minID
-            site_info['min_ID'] = minID
-        if maxID:
-            max_ID = maxID
-            site_info['max_ID'] = maxID
+        min_ID = site_info.get('min_ID',None)
+        max_ID = site_info.get('max_ID',None)
+        filterIDs = site_info.get('filterIDs',None)
+        # backward compability. Deleter after new frontend releases
+        if min_ID is not None and max_ID is not None:
+            filterIDs = str(min_ID)+"-"+str(max_ID)
         # Creating stations from the csv input file
         z1_tag = 0
         z25_tag = 0
@@ -141,7 +138,7 @@ def hazard_job(hazard_info):
         else:
             vs30_tag = 0
         # Creating stations from the csv input file
-        stations = create_stations(input_file, output_file, min_ID, max_ID, vs30_tag, z1_tag, z25_tag)
+        stations = create_stations(input_file, output_file, filterIDs, vs30_tag, z1_tag, z25_tag)
     if stations:
         print('HazardSimulation: stations created.')
     else:


### PR DESCRIPTION
The NNE.py should select grid points that have extra(other than lat and lon) key values equal to AIM values. E.g., select grid points with SoilType value equal to the SoilType value of the AIM.