### PR TITLE
solve the 'tar' problem in R2D's python session

### DIFF
--- a/modules/performRegionalEventSimulation/regionalGroundMotion/HazardSimulation.py
+++ b/modules/performRegionalEventSimulation/regionalGroundMotion/HazardSimulation.py
@@ -461,12 +461,6 @@ if __name__ == '__main__':
         # import FetchOpenQuake
         from FetchOpenQuake import *
 
-    # untar site databases
-    site_database = ['global_vs30_4km.tar.gz','global_zTR_4km.tar.gz','thompson_vs30_4km.tar.gz']
-    print('HazardSimulation: Extracting site databases.')
-    cwd = os.path.dirname(os.path.realpath(__file__))
-    for cur_database in site_database:
-        subprocess.run(["tar","-xvzf",cwd+"/database/site/"+cur_database,"-C",cwd+"/database/site/"])
 
     # Initial process list
     import psutil

--- a/modules/performRegionalEventSimulation/regionalGroundMotion/ScenarioForecast.py
+++ b/modules/performRegionalEventSimulation/regionalGroundMotion/ScenarioForecast.py
@@ -46,6 +46,7 @@ import numpy as np
 import pandas as pd
 import time
 import importlib
+import tarfile
 
 if __name__ == '__main__':
 
@@ -127,7 +128,10 @@ if __name__ == '__main__':
     print('HazardSimulation: Extracting site databases.')
     cwd = os.path.dirname(os.path.realpath(__file__))
     for cur_database in site_database:
-        subprocess.run(["tar","-xvzf",cwd+"/database/site/"+cur_database,"-C",cwd+"/database/site/"])
+        # subprocess.run(["tar","-xvzf",cwd+"/database/site/"+cur_database,"-C",cwd+"/database/site/"])
+        tar = tarfile.open(cwd+"/database/site/"+cur_database, "r:gz")
+        tar.extractall(cwd+"/database/site/")
+        tar.close()
 
     # # Initial process list
     # import psutil


### PR DESCRIPTION
R2D runs Python with a non-interactive shell, and many aliases, e.g., "which" and "tar," are not defined in a non-interactive shell. So instead of using subprocess.run('tar'...), use the python built-in package "tarfile" to unzip files.