### PR TITLE
Fix error in stochasticWaves that caused sensitivity analysis results to fail to visualize

### DIFF
--- a/modules/createEVENT/stochasticWave/Jonswap.py
+++ b/modules/createEVENT/stochasticWave/Jonswap.py
@@ -29,14 +29,14 @@ if __name__ == '__main__':
 
     input_args = sys.argv[1:]
 
-    print(  # noqa: T201
-        'Jonswap.py - Backend-script post_process_sensors.py running: '
-        + str(sys.argv[0])
-    )
-    print(  # noqa: T201
-        'post_process_sensors.py - Backend-script post_process_sensors.py received input args: '
-        + str(input_args)
-    )
+    # print(  # noqa: T201
+    #     'Jonswap.py - Backend-script post_process_sensors.py running: '
+    #     + str(sys.argv[0])
+    # )
+    # print(  # noqa: T201
+    #     'post_process_sensors.py - Backend-script post_process_sensors.py received input args: '
+    #     + str(input_args)
+    # )
 
     inputFile = sys.argv[1]  # noqa: N816
     outputPath = sys.argv[2]  # noqa: N816
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     with open(inputFile, encoding='utf-8') as BIMFile:  # noqa: PTH123
         bim = json.load(BIMFile)
         for event_id in range(1):
-            print('Running a sample simulation with JSON input parameters')  # noqa: T201
+            # print('Running a sample simulation with JSON input parameters')  # noqa: T201
             g = 9.80665  # gravity [m/s^2]
             rho = 1000.0  # water density
 
@@ -165,7 +165,7 @@ if __name__ == '__main__':
 
                         # if (si == seeds[-1]):
 
-                        print('Saving wave spectra and time series')  # noqa: T201
+                        # print('Saving wave spectra and time series')  # noqa: T201
                         spectra_df = pd.DataFrame()
 
                         spectra_df['Frequency'] = freq

--- a/modules/createEVENT/stochasticWave/StochasticWave.py
+++ b/modules/createEVENT/stochasticWave/StochasticWave.py
@@ -196,9 +196,9 @@ def readRV(aimFilePath='AIM.json', eventFilePath='EVENT.json'):  # noqa: D103, N
         addFloorForceToEvent(
             timeSeriesArray, patternsArray, floorForces.X, 'X', floor, deltaT
         )
-        addFloorForceToEvent(
-            timeSeriesArray, patternsArray, floorForces.Y, 'Y', floor, deltaT
-        )
+        # addFloorForceToEvent(
+        #     timeSeriesArray, patternsArray, floorForces.Y, 'Y', floor, deltaT
+        # )
         addFloorPressure(pressureArray, floor)
 
     eventDict['Events'].append(event_json)
@@ -237,9 +237,9 @@ def writeEVENT(forces, eventFilePath, deltaT=1.0):  # noqa: D103, N802, N803
         addFloorForceToEvent(
             timeSeriesArray, patternsArray, floorForces.X, 'X', floor, deltaT
         )
-        addFloorForceToEvent(
-            timeSeriesArray, patternsArray, floorForces.Y, 'Y', floor, deltaT
-        )
+        # addFloorForceToEvent(
+        #     timeSeriesArray, patternsArray, floorForces.Y, 'Y', floor, deltaT
+        # )
         addFloorPressure(pressureArray, floor)
 
     with open(eventFilePath, 'w', encoding='utf-8') as f:  # noqa: PTH123


### PR DESCRIPTION
Was an error of having 2dof when 1dof of freedom was completely locked causing Peak-interstory-displacements in the 2nd dof to be all zeroes, hence the sensitivity analysis visualizer failing because it couldn't handle the missing sobol data in dakota.